### PR TITLE
Error when running 'git fat pull' in a repository with symlink in it 

### DIFF
--- a/git-fat
+++ b/git-fat
@@ -158,7 +158,7 @@ class GitFat(object):
             return itertools.chain([preamble], readblocks(stream)), None
     def decode_file(self, fname):
         # Fast check
-        stat = os.stat(fname)
+        stat = os.lstat(fname)
         if stat.st_size != self.magiclen:
             return False, None
         # read file


### PR DESCRIPTION
Hi,

`git fat pull` seems to explode if there is a symlink committed in the working directory.

```
rserve@rserve-devel:~/tomas/clone$ toh/608-gitfat-experimentalmerge * = git fat pull
receiving file list ...
0 files to consider

sent 4 bytes received 6 bytes 20.00 bytes/sec
total size is 0 speedup is 0.00
Restoring 6957a37 -> data/wikidi_digital-camera/2012-10-prvni-data/better.params
Traceback (most recent call last):
File "/home/rserve/usr/git-fat/git-fat", line 467, in
fat.cmd_pull(sys.argv[2:])
File "/home/rserve/usr/git-fat/git-fat", line 338, in cmd_pull
self.checkout()
File "/home/rserve/usr/git-fat/git-fat", line 306, in checkout
for digest, fname in self.orphan_files():
File "/home/rserve/usr/git-fat/git-fat", line 268, in orphan_files
digest = self.decode_file(fname)[0]
File "/home/rserve/usr/git-fat/git-fat", line 161, in decode_file
stat = os.stat(fname)
OSError: [Errno 2] No such file or directory: 'data/wikidi_digital-camera/2012-10-prvni-data/crawl'
```

(data/wikidi_digital-camera/2012-10-prvni-data/crawl is a symlink)
