### PR TITLE
Added support for pulling only a subset of orphan objects

### DIFF
--- a/git-fat
+++ b/git-fat
@@ -262,12 +262,17 @@ class GitFat(object):
         p1.wait()
         p2.wait()
         return referenced
+
     def orphan_files(self):
+        return self.matching_orphan_files('') #no pattern by default -> get all
+
+    def matching_orphan_files(self, pattern):
         'generator for all orphan placeholders in the working tree'
-        for fname in subprocess.check_output(['git', 'ls-files']).splitlines():
+        for fname in subprocess.check_output(['git', 'ls-files', pattern]).splitlines():
             digest = self.decode_file(fname)[0]
             if digest:
                 yield (digest, fname)
+
     def cmd_status(self, args):
         self.setup()
         catalog = self.catalog_objects()
@@ -330,14 +335,34 @@ class GitFat(object):
             rev = self.revparse(arg)
             if rev:
                 refargs['rev'] = rev
-        files = self.referenced_objects(**refargs) - self.catalog_objects()
+        files = self.filter_objects(self.parse_pull_patterns(args), refargs)
         cmd = self.get_rsync_command(push=False)
         self.verbose('Executing: %s' % ' '.join(cmd))
         p = subprocess.Popen(cmd, stdin=subprocess.PIPE)
         p.communicate(input='\x00'.join(files))
         self.checkout()
+
+    def parse_pull_patterns(self, args):
+        if '--' not in args:
+            return ['']
+        else:
+            idx = args.index('--')
+            patterns  = args[idx+1:] #we don't care about '--' 
+            return patterns
+
+    def filter_objects(self, patterns, refargs):
+        files = self.referenced_objects(**refargs) - self.catalog_objects()
+        files_set = set(files)
+        orphans_matched = list(self.matching_orphan_files(' '.join(patterns)))
+        print("pulling:")
+        print(map(lambda x: x[1], orphans_matched))
+        orphans_objects = set(map(lambda x: x[0], orphans_matched))
+        return files_set & orphans_objects
+                             
+
     def cmd_checkout(self, args):
         self.checkout(show_orphans=True)
+
     def cmd_gc(self):
         garbage = self.catalog_objects() - self.referenced_objects()
         print('Unreferenced objects to remove: %d' % len(garbage))


### PR DESCRIPTION
I'm not sure if you are interested in this functionality, but I needed to be able to specify only a subset of files to be downloaded.

Usage is 

```
git fat pull --match 'python_regex_here'
```

and it should only download and restore files matching the regex
