### PR TITLE
fix "git fat pull" for fancy named files

### DIFF
--- a/git-fat
+++ b/git-fat
@@ -265,7 +265,7 @@ class GitFat(object):
 
     def orphan_files(self, patterns=[]):
         'generator for all orphan placeholders in the working tree'
-        for fname in subprocess.check_output(['git', 'ls-files'] + patterns).splitlines():
+        for fname in subprocess.check_output(['git', 'ls-files', '-z'] + patterns).split("\x00")[:-1]:
             digest = self.decode_file(fname)[0]
             if digest:
                 yield (digest, fname)


### PR DESCRIPTION
Hi,

in this PR I've just added `-z` to `git ls-files` and the result is split at `\x00` instead of `\n` (as this is the new separator). 

A simple change but now we're getting the original filename back from git and are able to handle names containing spaces and/or fancy utf8 characters.

Feel free to request changes if I missed something crucial.
