### PR TITLE
Add config option to allow passing --chmod to rsync

### DIFF
--- a/git-fat
+++ b/git-fat
@@ -106,11 +106,12 @@ class GitFat(object):
         remote    = gitconfig_get('rsync.remote', file=cfgpath)
         ssh_port  = gitconfig_get('rsync.sshport', file=cfgpath)
         ssh_user  = gitconfig_get('rsync.sshuser', file=cfgpath)
+        chmod     = gitconfig_get('rsync.chmod', file=cfgpath)
         if remote is None:
             raise RuntimeError('No rsync.remote in %s' % cfgpath)
-        return remote, ssh_port, ssh_user
+        return remote, ssh_port, ssh_user, chmod
     def get_rsync_command(self,push):
-        (remote, ssh_port, ssh_user) = self.get_rsync()
+        (remote, ssh_port, ssh_user, chmod) = self.get_rsync()
         if push:
             self.verbose('Pushing to %s' % (remote))
         else:
@@ -124,6 +125,8 @@ class GitFat(object):
             rshopts += ' -p ' + ssh_port
         if rshopts:
             cmd.append('--rsh=ssh' + rshopts)
+        if chmod:
+            cmd.append('--chmod=' + chmod)
         if push:
             cmd += [self.objdir + '/', remote + '/']
         else:


### PR DESCRIPTION
I needed something like this when sharing the rsync'd location between several users, but the fat-pushed files were made as user-read-write only, which rsync dutifully reproduced in the shared location too.

I hope this is a useful thing to include.

Thanks for the handy tool; it helped us move an otherwise obstinate repo out of svn but preserve the entire history.
