### PR TITLE
ignore symbolic links during index-filter

### DIFF
--- a/git-fat
+++ b/git-fat
@@ -444,6 +444,9 @@ class GitFat(object):
             filename = tail.strip()
             if filename not in filelist:
                 continue
+            if mode == "120000":
+                # skip symbolic links
+                continue
             # This file will contain the hash of the cleaned object
             hashfile = os.path.join(self.gitdir, 'fat', 'index-filter', blobhash)
             try:


### PR DESCRIPTION
symbolic links should not be handled by git-fat even if
their name match the filelist
