### PR TITLE
fix handling of broken symlinks

### DIFF
--- a/git-fat
+++ b/git-fat
@@ -194,7 +194,10 @@ class GitFat(object):
         if stat.st_size != self.magiclen:
             return False, None
         # read file
-        digest, bytes = self.decode_stream(open(fname))
+        try:
+            digest, bytes = self.decode_stream(open(fname))
+        except IOError:
+            return False, None
         if isinstance(digest, str):
             return digest, bytes
         else:

--- a/test.sh
+++ b/test.sh
@@ -13,6 +13,9 @@ echo '*.fat filter=fat -crlf' > .gitattributes
 git add .gitattributes .gitfat
 git commit -m'Initial fat repository'
 
+ln -s /oe/dss-oe/dss-add-ons-testing-build/deploy/licenses/common-licenses/GPL-3 c
+git add c
+git commit -m'add broken symlink'
 echo 'fat content a' > a.fat
 git add a.fat
 git commit -m'add a.fat'


### PR DESCRIPTION
if a symlink has a length of self.magiclen git-fat would crash
because it could not read the file
