### PR TITLE
Explain rsync with ssh authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,17 @@ Set a remote store for the fat objects by editing `.gitfat`.
 
 This file should typically be committed to the repository so that others
 will automatically have their remote set. This remote address can use
-any protocol supported by rsync. Most users will configure it to use
-remote ssh in a directory with shared access.
+any protocol supported by rsync. 
+
+Most users will configure it to use remote ssh in a directory with shared 
+access. To do this, set the `sshuser` and `sshport` variables in `.gitfat` 
+configuration file. For example, to use rsync with ssh, with the default
+port (22) and authenticate with the user "_fat_", your configuration would 
+look like this: 
+
+    [rsync]
+    remote = your.remote-host.org:/share/fat-store
+    sshuser = fat
 
 # A worked example
 


### PR DESCRIPTION
I did not find any documentation on this, just the readme hint that it is possible. Looking into the code I found the appropriate variables that are needed. Having this documented would be nice. 

btw, `git help fat` or `git fat --help` would be nice to have a small message saying that help is not available at the moment, instead of a dump. 

Thanks!
