### PR TITLE
Adding support for extra rsync options via rsync.options

### DIFF
--- a/git-fat
+++ b/git-fat
@@ -158,7 +158,7 @@ class GitFat(object):
         if rshopts:
             cmd.append('--rsh=ssh' + rshopts)
         if options:
-            cmd.append(options)
+            cmd += options.split(' ')
         if push:
             cmd += [self.objdir + '/', remote + '/']
         else:


### PR DESCRIPTION
I want to use git-fat for special case of deployment of files for the Wikimedia Foundation.  I want to manually manage a git-fat store (no push) using symlinks to .jar files in an Archiva repository. However, currently git-fat does not support rsync's --copy-links, which I need in order to be able to pull down the actual files.

This pull requests allows for arbitrary rsync options settings like:

```
[rsync]
...
options = --copy-links --verbose
```
