### PR TITLE
Allow git-fat settings to come from global git configuration

### DIFF
--- a/git-fat
+++ b/git-fat
@@ -105,8 +105,10 @@ def gitconfig_get(name, file=None):
     args.append(name)
     p = subprocess.Popen(args, stdout=subprocess.PIPE)
     output = p.communicate()[0].strip()
-    if p.returncode != 0:
+    if p.returncode and file is None:
         return None
+    elif p.returncode:
+        return gitconfig_get(name)
     else:
         return output
 def gitconfig_set(name, value, file=None):


### PR DESCRIPTION
Being able to configure settings like rsync.remote on a per-repository basis is great.

However, I'd also like the ability to configure settings like rsync.sshuser on a per user basis. For example, my sshusername might be chrismarinos, but yours might be jedbrown. This is especially handy when your sshuser is different from your local machine's user name.

This patch makes that possible.
