### PR TITLE
fix OSError on “git fat pull” with manually removed, tracked files in WC

### DIFF
--- a/git-fat
+++ b/git-fat
@@ -195,7 +195,10 @@ class GitFat(object):
             return itertools.chain([preamble], readblocks(stream)), None
     def decode_file(self, fname):
         # Fast check
-        stat = os.lstat(fname)
+        try:
+            stat = os.lstat(fname)
+        except OSError:
+            return False, None
         if stat.st_size != self.magiclen:
             return False, None
         # read file

--- a/test.sh
+++ b/test.sh
@@ -32,3 +32,9 @@ cd fat-test2
 git fat init
 git fat pull -- 'a.fa*'
 cat a.fat
+echo 'file which is committed and removed afterwards' > d
+git add d
+git commit -m'add d with normal content'
+rm d
+git fat pull
+


### PR DESCRIPTION
If there is any manually removed, tracked file in the working copy, then
running “git fat pull” fails with an OSError without this fix.
