### PR TITLE
Print filenames for objects in `status` output with '--filenames' option

### DIFF
--- a/git-fat
+++ b/git-fat
@@ -317,6 +317,10 @@ class GitFat(object):
                 objhash, objtype, size = line.split()
                 if objtype == 'blob' and int(size) in self.magiclens:
                     output.write(objhash + '\n')
+                else:
+                    # Ignore filename(s) for git hashes that are not git-fat objects
+                    if with_filenames and objhash in githash_to_filenames:
+                        del githash_to_filenames[objhash]
             output.close()
         # ...`cat-file --batch` provides full contents of git-fat candidates in bulk
         p3 = subprocess.Popen(['git','cat-file','--batch'], stdin=subprocess.PIPE, stdout=subprocess.PIPE)


### PR DESCRIPTION
The '--filenames' option makes it easy to view the filename represented
by a git-fat object reference, at the cost of a slight performance
and memory hit compared to the plain `git-fat status` command.

This option is most helpful when you are thinking about running
`git-fat gc` to clean up some garbage/unreferenced objects, so you
can check what you are about to delete.
- Add referenced_objects_with_filenames() method that (optionally)
  stores file name data while looking up git-fat referenced objects.
- Refactor referenced_objects() method to use the above method while
  providing existing interface.
- If '--filenames' option is given to the `status` command, print
  filename(s) next to git-fat object hash values.
