### PR TITLE
Invalidate git index cache before smudging

### DIFF
--- a/git-fat
+++ b/git-fat
@@ -412,11 +412,18 @@ class GitFat(object):
                 # the file in .git/fat/objects, but git caches the file stat
                 # from the previous time the file was smudged, therefore it
                 # won't try to re-smudge. I don't know a git command that
-                # specifically invalidates that cache, but touching the file
-                # also does the trick.
-                os.utime(fname, None)
-                # This re-smudge is essentially a copy that restores permissions.
-                subprocess.check_call(['git', 'checkout-index', '--index', '--force', fname])
+                # specifically invalidates that cache, but changing the mtime
+                # on the file will invalidate the cache.
+                # Here we set the mtime to mtime + 1. This is an improvement
+                # over touching the file as it catches the edgecase where a
+                # git-checkout happens within the same second as a git fat
+                # checkout.
+                stat = os.lstat(fname)
+                os.utime(fname, (stat.st_atime, stat.st_mtime + 1))
+                # This re-smudge is essentially a copy that restores
+                # permissions.
+                subprocess.check_call(
+                    ['git', 'checkout-index', '--index', '--force', fname])
             elif show_orphans:
                 print('Data unavailable: %s %s' % (digest,fname))
     def cmd_pull(self, args):


### PR DESCRIPTION
At Wikimedia we shell-out to git-fat from inside another piece of software. As a result we occasionally hit the problem where a git smudge filter is not triggered since there's a fair chance that the `os.utime` call inside `git-fat` that is intended to invalidate the git index cache is triggered within the same second as a git checkout. In those instances, git will not trigger the smudge filter and the file in the checkout will remain orphaned.

We worked around this by ensuring that the timestamp on a file is modified by looking at its previous timestamp and adding 1 to it. Submitting as a pull-request here in case this might be generally useful.