### PR TITLE
Fix git ls-files -z to use '.' instead of a empty string

### DIFF
--- a/git-fat
+++ b/git-fat
@@ -359,7 +359,7 @@ class GitFat(object):
 
     def orphan_files(self, patterns=[]):
         'generator for all orphan placeholders in the working tree'
-        if not patterns or patterns == ['']:
+        if not patterns or patterns == ['.']:
             patterns = ['.']
         for fname in subprocess.check_output(['git', 'ls-files', '-z'] + patterns).split('\x00')[:-1]:
             digest = self.decode_file(fname)[0]


### PR DESCRIPTION
In newer git versions using a empty string with git ls-files -z causes a hard failure.

fatal: empty string is not a valid pathspec. please use . instead if you meant to match all paths

That use to be a warning but now fails hard.